### PR TITLE
keeping home_loc / work_loc

### DIFF
--- a/howde/HoWDe_utils.py
+++ b/howde/HoWDe_utils.py
@@ -612,6 +612,8 @@ def get_stop_level(df_stops, df_traj):
         )
         .withColumnRenamed("s_date", "date")
         .select(cols)
+        .withColumnRenamed("HomPot_loc", "home_loc")
+        .withColumnRenamed("EmpPot_loc", "work_loc")
     )
     return stops_hw
 


### PR DESCRIPTION
Maintaining the home_loc/work_loc allows us to visualize the detected home/work across all days. Example: If in weeks [0, i] we detected loc 45 as Home, but in Week i+1 we do not visit home, we can still predict 45 as Home (thanks to the window aggregations). This is visible in home_loc, but not in locations_labels.