### PR TITLE
keeping home/work loc columns in HoWDe_core.py

### DIFF
--- a/howde/HoWDe_core.py
+++ b/howde/HoWDe_core.py
@@ -52,7 +52,7 @@ def HoWDe_compute(df_stops=None, config={}, stops_output=True, verbose=False):
 
     ## Select output style: stops or change level
     if stops_output:
-        df_f = get_stop_level(df_stops, df_f).drop(*["HomPot_loc", "EmpPot_loc"])
+        df_f = get_stop_level(df_stops, df_f)#.drop(*["HomPot_loc", "EmpPot_loc"])
     else:
         df_f = get_change_level(df_f)
 


### PR DESCRIPTION
Maintaining the home_loc/work_loc allows us to visualize the detected home/work across all days. Example: If in weeks [0, i] we detected loc 45 as Home, but in Week i+1 we do not visit home, we can still predict 45 as Home (thanks to the window aggregations). This is visible in home_loc, but not in locations_labels.