### PR TITLE
update on return parametres, keep H/W loc

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ def HoWDe_labelling(
 
 #### Returns
 
-- A PySpark DataFrame with an additional column `location_type` indicating the detected location type ('H' for Home, 'W' for Work, or None). The label is assigned based on whether the location satisfies all filtering criteria within a sliding time window. As such, location_type represents a day-level assessment, taking into account observations from neighboring days within the range t+/- range_window/2.
+A PySpark DataFrame with three additional columns:
+- `detect_H_loc` the location id of the location identified as Home.  The label is assigned based on whether the location satisfies all filtering criteria within a sliding time window. As such, represents a day-level assessment, taking into account observations from neighboring days within the range t+/- range_window/2.
+- `detect_W_loc` the location id of the location identified as Work.  The label is assigned based on whether the location satisfies all filtering criteria within a sliding time window. As such, represents a day-level assessment, taking into account observations from neighboring days within the range t+/- range_window/2.
+- `location_type` indicating the detected location type ('H' for Home, 'W' for Work, or None). The label is assigned based on whether the location satisfies all filtering criteria within a sliding time window. As such, location_type represents a day-level assessment, taking into account observations from neighboring days within the range t+/- range_window/2.
+
 
 ## Example Usage
 

--- a/howde/HoWDe_utils.py
+++ b/howde/HoWDe_utils.py
@@ -669,8 +669,8 @@ def get_change_level(df):
         .withColumn("end_date", F.unix_timestamp(F.col("end_date")))
         ## Keep only change level
         .select(["useruuid", "start_date", "end_date", "HomPot_loc", "EmpPot_loc"])
-        .withColumnRenamed("HomPot_loc", "home_loc")
-        .withColumnRenamed("EmpPot_loc", "work_loc")
+        .withColumnRenamed("HomPot_loc", "detect_H_loc")
+        .withColumnRenamed("EmpPot_loc", "detect_W_loc")
         .dropDuplicates()
     )
     return df


### PR DESCRIPTION
## Modifications
updated nomenclarure for the home and work location

## Usage
by only keeping the location_label, we loose information on the home/work detected if the particular location was not detected on a given day.
Example: Weeks[0, i] : we detected loc = 45 as Home, in Week i+1 we do not visit home but still predict loc=45 as Home, by dropping HomePot we will only have locations_labels = ‘H’ in week i and not in i+1.